### PR TITLE
Harmony patch changes to make the mod work on 64 bit, also added SMAPI 3.12 Harmony changes

### DIFF
--- a/HardyGrass/ModEntry.cs
+++ b/HardyGrass/ModEntry.cs
@@ -9,6 +9,7 @@ using StardewValley;
 using StardewValley.Tools;
 using StardewValley.TerrainFeatures;
 using Harmony;
+using Microsoft.Xna.Framework;
 
 namespace HardyGrass
 {
@@ -54,7 +55,60 @@ namespace HardyGrass
             Helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
 
             var harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
-            harmony.PatchAll();
+            //Animals
+            harmony.Patch(
+               original: AccessTools.Method(typeof(FarmAnimal), "grassEndPointFunction", new Type[] { typeof(PathNode), typeof(Point), typeof(GameLocation), typeof(Character) }),
+               prefix: new HarmonyMethod(typeof(FarmAnimal_grassEndPointFunction_Patch), nameof(FarmAnimal_grassEndPointFunction_Patch.Prefix))
+            );
+            harmony.Patch(
+               original: AccessTools.Method(typeof(FarmAnimal), "Eat", new Type[] { typeof(GameLocation) }),
+               prefix: new HarmonyMethod(typeof(FarmAnimal_Eat_Patch), nameof(FarmAnimal_Eat_Patch.Prefix))
+            );
+            //GameLocation
+            harmony.Patch(
+               original: AccessTools.Method(typeof(GameLocation), "growWeedGrass", new Type[] { typeof(int) }),
+               prefix: new HarmonyMethod(typeof(GameLocation_growWeedGrass_Patch), nameof(GameLocation_growWeedGrass_Patch.Prefix))
+            );
+
+            //Grass
+            harmony.Patch(
+               original: AccessTools.Method(typeof(StardewValley.TerrainFeatures.Grass), "dayUpdate", new Type[] { typeof(GameLocation), typeof(Vector2) }),
+               prefix: new HarmonyMethod(typeof(Grass_dayUpdate_Patch), nameof(Grass_dayUpdate_Patch.Prefix))
+            );
+            harmony.Patch(
+               original: AccessTools.Method(typeof(StardewValley.TerrainFeatures.Grass), "reduceBy", new Type[] { typeof(int), typeof(Vector2), typeof(bool) }),
+               postfix: new HarmonyMethod(typeof(Grass_reduceBy_Patch), nameof(Grass_reduceBy_Patch.Postfix))
+            );
+            harmony.Patch(
+               original: AccessTools.Method(typeof(StardewValley.TerrainFeatures.Grass), "doCollisionAction", new Type[] { typeof(Rectangle), typeof(int), typeof(Vector2), typeof(Character), typeof(GameLocation) }),
+               prefix: new HarmonyMethod(typeof(Grass_doCollisionAction_Patch), nameof(Grass_doCollisionAction_Patch.Prefix))
+            );
+            harmony.Patch(
+               original: AccessTools.Method(typeof(StardewValley.TerrainFeatures.Grass), "performToolAction", new Type[] { typeof(Tool), typeof(int), typeof(Vector2), typeof(GameLocation) }),
+               prefix: new HarmonyMethod(typeof(Grass_performToolAction_Patch), nameof(Grass_performToolAction_Patch.Prefix))
+            );
+            harmony.Patch(
+               original: AccessTools.Method(typeof(StardewValley.TerrainFeatures.Grass), "performToolAction", new Type[] { typeof(Tool), typeof(int), typeof(Vector2), typeof(GameLocation) }),
+               postfix: new HarmonyMethod(typeof(Grass_performToolAction_Patch), nameof(Grass_performToolAction_Patch.Postfix))
+            );
+            harmony.Patch(
+               original: AccessTools.Method(typeof(StardewValley.TerrainFeatures.Grass), "draw", new Type[] { typeof(SpriteBatch), typeof(Vector2) }),
+               prefix: new HarmonyMethod(typeof(Grass_draw_Patch), nameof(Grass_draw_Patch.Prefix))
+            );
+            //Objects
+            harmony.Patch(
+               original: AccessTools.Method(typeof(StardewValley.Object), "placementAction", new Type[] { typeof(GameLocation), typeof(int), typeof(int), typeof(Farmer) }),
+               prefix: new HarmonyMethod(typeof(Object_placementAction_Patch), nameof(Object_placementAction_Patch.Prefix))
+            );
+            harmony.Patch(
+              original: AccessTools.Method(typeof(StardewValley.Object), "isPlaceable", new Type[] { }),
+              postfix: new HarmonyMethod(typeof(Object_isPlaceable_Patch), nameof(Object_isPlaceable_Patch.Postfix))
+            );
+            harmony.Patch(
+              original: AccessTools.Method(typeof(StardewValley.Object), "isPassable", new Type[] { }),
+              postfix: new HarmonyMethod(typeof(Object_isPassable_Patch), nameof(Object_isPassable_Patch.Postfix))
+            );
+
         }
 
         /*********

--- a/HardyGrass/ModEntry.cs
+++ b/HardyGrass/ModEntry.cs
@@ -8,7 +8,7 @@ using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Tools;
 using StardewValley.TerrainFeatures;
-using Harmony;
+using HarmonyLib;
 using Microsoft.Xna.Framework;
 
 namespace HardyGrass
@@ -54,7 +54,7 @@ namespace HardyGrass
             Helper.Events.GameLoop.GameLaunched += OnGameLaunched;
             Helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
 
-            var harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
+            var harmony = new Harmony(this.ModManifest.UniqueID);
             //Animals
             harmony.Patch(
                original: AccessTools.Method(typeof(FarmAnimal), "grassEndPointFunction", new Type[] { typeof(PathNode), typeof(Point), typeof(GameLocation), typeof(Character) }),

--- a/HardyGrass/Overrides/FarmAnimalPatches.cs
+++ b/HardyGrass/Overrides/FarmAnimalPatches.cs
@@ -6,8 +6,10 @@ using Harmony;
 
 namespace HardyGrass
 {
+    /*
     [HarmonyPatch(typeof(FarmAnimal))]
     [HarmonyPatch("grassEndPointFunction", new Type[] {typeof(PathNode), typeof(Point), typeof(GameLocation), typeof(Character)})]
+    */
     public class FarmAnimal_grassEndPointFunction_Patch
     {
         public static bool Prefix(ref bool __result, PathNode currentPoint, Point endPoint, GameLocation location, Character c)
@@ -29,8 +31,8 @@ namespace HardyGrass
         }
     }
 
-    [HarmonyPatch(typeof(FarmAnimal))]
-    [HarmonyPatch("Eat", new Type[] { typeof(GameLocation) })]
+    //[HarmonyPatch(typeof(FarmAnimal))]
+    //[HarmonyPatch("Eat", new Type[] { typeof(GameLocation) })]
     public class FarmAnimal_Eat_Patch
     {
         public static bool Prefix(FarmAnimal __instance, GameLocation location)

--- a/HardyGrass/Overrides/FarmAnimalPatches.cs
+++ b/HardyGrass/Overrides/FarmAnimalPatches.cs
@@ -2,14 +2,11 @@
 using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.TerrainFeatures;
-using Harmony;
+using HarmonyLib;
 
 namespace HardyGrass
 {
-    /*
-    [HarmonyPatch(typeof(FarmAnimal))]
-    [HarmonyPatch("grassEndPointFunction", new Type[] {typeof(PathNode), typeof(Point), typeof(GameLocation), typeof(Character)})]
-    */
+
     public class FarmAnimal_grassEndPointFunction_Patch
     {
         public static bool Prefix(ref bool __result, PathNode currentPoint, Point endPoint, GameLocation location, Character c)
@@ -31,8 +28,6 @@ namespace HardyGrass
         }
     }
 
-    //[HarmonyPatch(typeof(FarmAnimal))]
-    //[HarmonyPatch("Eat", new Type[] { typeof(GameLocation) })]
     public class FarmAnimal_Eat_Patch
     {
         public static bool Prefix(FarmAnimal __instance, GameLocation location)

--- a/HardyGrass/Overrides/GameLocationPatches.cs
+++ b/HardyGrass/Overrides/GameLocationPatches.cs
@@ -8,11 +8,11 @@ using Harmony;
 
 namespace HardyGrass
 {
-    [HarmonyPatch(typeof(GameLocation))]
-    [HarmonyPatch("growWeedGrass", new Type[] { typeof(int) })]
+    //[HarmonyPatch(typeof(GameLocation))]
+    //[HarmonyPatch("growWeedGrass", new Type[] { typeof(int) })]
     public class GameLocation_growWeedGrass_Patch
     {
-        static bool Prefix(GameLocation __instance, int iterations)
+        internal static bool Prefix(GameLocation __instance, int iterations)
         {
             for (int i = 0; i < iterations; i++)
             {

--- a/HardyGrass/Overrides/GameLocationPatches.cs
+++ b/HardyGrass/Overrides/GameLocationPatches.cs
@@ -4,12 +4,10 @@ using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.TerrainFeatures;
 using Location = xTile.Dimensions.Location;
-using Harmony;
+using HarmonyLib;
 
 namespace HardyGrass
 {
-    //[HarmonyPatch(typeof(GameLocation))]
-    //[HarmonyPatch("growWeedGrass", new Type[] { typeof(int) })]
     public class GameLocation_growWeedGrass_Patch
     {
         internal static bool Prefix(GameLocation __instance, int iterations)

--- a/HardyGrass/Overrides/GrassPatches.cs
+++ b/HardyGrass/Overrides/GrassPatches.cs
@@ -4,12 +4,10 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.Tools;
 using StardewValley.TerrainFeatures;
-using Harmony;
+using HarmonyLib;
 
 namespace HardyGrass
 {
-    //[HarmonyPatch(typeof(Grass))]
-    //[HarmonyPatch("dayUpdate", new Type[] { typeof(GameLocation), typeof(Vector2) })]
     public class Grass_dayUpdate_Patch
     {
         internal static bool Prefix(Grass __instance, GameLocation environment, Vector2 tileLocation)
@@ -24,8 +22,6 @@ namespace HardyGrass
         }
     }
 
-    //[HarmonyPatch(typeof(Grass))]
-    //[HarmonyPatch("reduceBy", new Type[] { typeof(int), typeof(Vector2), typeof(bool) })]
     public class Grass_reduceBy_Patch
     {
         internal static void Postfix(Grass __instance, ref bool __result)
@@ -41,8 +37,6 @@ namespace HardyGrass
         }
     }
 
-    //[HarmonyPatch(typeof(Grass))]
-    //[HarmonyPatch("doCollisionAction", new Type[] { typeof(Rectangle), typeof(int), typeof(Vector2), typeof(Character), typeof(GameLocation) })]
     public class Grass_doCollisionAction_Patch
     {
         internal static bool Prefix(Grass __instance, float ___maxShake, float ___shakeRotation, Rectangle positionOfCollider, int speedOfCollision, Vector2 tileLocation, Character who, GameLocation location)
@@ -79,8 +73,6 @@ namespace HardyGrass
         }
     }
 
-    //[HarmonyPatch(typeof(Grass))]
-    //[HarmonyPatch("performToolAction", new Type[] { typeof(Tool), typeof(int), typeof(Vector2), typeof(GameLocation)})]
     public class Grass_performToolAction_Patch
     {
         internal static bool Prefix(Grass __instance, ref bool __result, Tool t, int explosion, Vector2 tileLocation, GameLocation location)
@@ -151,8 +143,6 @@ namespace HardyGrass
         }
     }
 
-    //[HarmonyPatch(typeof(Grass))]
-    //[HarmonyPatch("draw", new Type[] { typeof(SpriteBatch), typeof(Vector2) })]
     public class Grass_draw_Patch
     {
         internal static bool Prefix(Grass __instance, SpriteBatch spriteBatch, Vector2 tileLocation, int[] ___whichWeed, int[] ___offset1, int[] ___offset2, int[] ___offset3, int[] ___offset4, bool[] ___flip, double[] ___shakeRandom, float ___shakeRotation)

--- a/HardyGrass/Overrides/GrassPatches.cs
+++ b/HardyGrass/Overrides/GrassPatches.cs
@@ -8,11 +8,11 @@ using Harmony;
 
 namespace HardyGrass
 {
-    [HarmonyPatch(typeof(Grass))]
-    [HarmonyPatch("dayUpdate", new Type[] { typeof(GameLocation), typeof(Vector2) })]
+    //[HarmonyPatch(typeof(Grass))]
+    //[HarmonyPatch("dayUpdate", new Type[] { typeof(GameLocation), typeof(Vector2) })]
     public class Grass_dayUpdate_Patch
     {
-        static bool Prefix(Grass __instance, GameLocation environment, Vector2 tileLocation)
+        internal static bool Prefix(Grass __instance, GameLocation environment, Vector2 tileLocation)
         {
             if ((byte)__instance.grassType == 1 && !environment.GetSeasonForLocation().Equals("winter") && (int)__instance.numberOfWeeds < 4)
             {
@@ -24,11 +24,11 @@ namespace HardyGrass
         }
     }
 
-    [HarmonyPatch(typeof(Grass))]
-    [HarmonyPatch("reduceBy", new Type[] { typeof(int), typeof(Vector2), typeof(bool) })]
+    //[HarmonyPatch(typeof(Grass))]
+    //[HarmonyPatch("reduceBy", new Type[] { typeof(int), typeof(Vector2), typeof(bool) })]
     public class Grass_reduceBy_Patch
     {
-        static void Postfix(Grass __instance, ref bool __result)
+        internal static void Postfix(Grass __instance, ref bool __result)
         {
             __result = false;
 
@@ -41,11 +41,11 @@ namespace HardyGrass
         }
     }
 
-    [HarmonyPatch(typeof(Grass))]
-    [HarmonyPatch("doCollisionAction", new Type[] { typeof(Rectangle), typeof(int), typeof(Vector2), typeof(Character), typeof(GameLocation) })]
+    //[HarmonyPatch(typeof(Grass))]
+    //[HarmonyPatch("doCollisionAction", new Type[] { typeof(Rectangle), typeof(int), typeof(Vector2), typeof(Character), typeof(GameLocation) })]
     public class Grass_doCollisionAction_Patch
     {
-        static bool Prefix(Grass __instance, float ___maxShake, float ___shakeRotation, Rectangle positionOfCollider, int speedOfCollision, Vector2 tileLocation, Character who, GameLocation location)
+        internal static bool Prefix(Grass __instance, float ___maxShake, float ___shakeRotation, Rectangle positionOfCollider, int speedOfCollision, Vector2 tileLocation, Character who, GameLocation location)
         {
             if (location != Game1.currentLocation)
             {
@@ -79,17 +79,17 @@ namespace HardyGrass
         }
     }
 
-    [HarmonyPatch(typeof(Grass))]
-    [HarmonyPatch("performToolAction", new Type[] { typeof(Tool), typeof(int), typeof(Vector2), typeof(GameLocation)})]
+    //[HarmonyPatch(typeof(Grass))]
+    //[HarmonyPatch("performToolAction", new Type[] { typeof(Tool), typeof(int), typeof(Vector2), typeof(GameLocation)})]
     public class Grass_performToolAction_Patch
     {
-        static bool Prefix(Grass __instance, ref bool __result, Tool t, int explosion, Vector2 tileLocation, GameLocation location)
+        internal static bool Prefix(Grass __instance, ref bool __result, Tool t, int explosion, Vector2 tileLocation, GameLocation location)
         {
             __result = false;
             return (int)__instance.numberOfWeeds > 0;
         }
 
-        static void Postfix(Grass __instance, ref bool __result, Tool t, int explosion, Vector2 tileLocation, GameLocation location)
+        internal static void Postfix(Grass __instance, ref bool __result, Tool t, int explosion, Vector2 tileLocation, GameLocation location)
         {
             __instance.numberOfWeeds.Value = Math.Max(0, (int)__instance.numberOfWeeds);
 
@@ -151,11 +151,11 @@ namespace HardyGrass
         }
     }
 
-    [HarmonyPatch(typeof(Grass))]
-    [HarmonyPatch("draw", new Type[] { typeof(SpriteBatch), typeof(Vector2) })]
+    //[HarmonyPatch(typeof(Grass))]
+    //[HarmonyPatch("draw", new Type[] { typeof(SpriteBatch), typeof(Vector2) })]
     public class Grass_draw_Patch
     {
-        static bool Prefix(Grass __instance, SpriteBatch spriteBatch, Vector2 tileLocation, int[] ___whichWeed, int[] ___offset1, int[] ___offset2, int[] ___offset3, int[] ___offset4, bool[] ___flip, double[] ___shakeRandom, float ___shakeRotation)
+        internal static bool Prefix(Grass __instance, SpriteBatch spriteBatch, Vector2 tileLocation, int[] ___whichWeed, int[] ___offset1, int[] ___offset2, int[] ___offset3, int[] ___offset4, bool[] ___flip, double[] ___shakeRandom, float ___shakeRotation)
         {
             for (int i = 0; i < 4; i++)
             {

--- a/HardyGrass/Overrides/ObjectPatches.cs
+++ b/HardyGrass/Overrides/ObjectPatches.cs
@@ -2,12 +2,10 @@
 using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.TerrainFeatures;
-using Harmony;
+using HarmonyLib;
 
 namespace HardyGrass
 {
-    //[HarmonyPatch(typeof(StardewValley.Object))]
-    //[HarmonyPatch("placementAction", new Type[] { typeof(GameLocation), typeof(int), typeof(int), typeof(Farmer) })]
     public class Object_placementAction_Patch
     {
         public static bool Prefix(StardewValley.Object __instance, ref bool __result, GameLocation location, int x, int y, Farmer who)
@@ -38,8 +36,6 @@ namespace HardyGrass
         }
     }
 
-    //[HarmonyPatch(typeof(StardewValley.Object))]
-    //[HarmonyPatch("isPlaceable", new Type[] { })]
     public class Object_isPlaceable_Patch
     {
         public static void Postfix(StardewValley.Object __instance, ref bool __result)
@@ -52,8 +48,6 @@ namespace HardyGrass
         }
     }
 
-    //[HarmonyPatch(typeof(StardewValley.Object))]
-    //[HarmonyPatch("isPassable", new Type[] { })]
     public class Object_isPassable_Patch
     {
         public static void Postfix(StardewValley.Object __instance, ref bool __result)

--- a/HardyGrass/Overrides/ObjectPatches.cs
+++ b/HardyGrass/Overrides/ObjectPatches.cs
@@ -6,8 +6,8 @@ using Harmony;
 
 namespace HardyGrass
 {
-    [HarmonyPatch(typeof(StardewValley.Object))]
-    [HarmonyPatch("placementAction", new Type[] { typeof(GameLocation), typeof(int), typeof(int), typeof(Farmer) })]
+    //[HarmonyPatch(typeof(StardewValley.Object))]
+    //[HarmonyPatch("placementAction", new Type[] { typeof(GameLocation), typeof(int), typeof(int), typeof(Farmer) })]
     public class Object_placementAction_Patch
     {
         public static bool Prefix(StardewValley.Object __instance, ref bool __result, GameLocation location, int x, int y, Farmer who)
@@ -38,8 +38,8 @@ namespace HardyGrass
         }
     }
 
-    [HarmonyPatch(typeof(StardewValley.Object))]
-    [HarmonyPatch("isPlaceable", new Type[] { })]
+    //[HarmonyPatch(typeof(StardewValley.Object))]
+    //[HarmonyPatch("isPlaceable", new Type[] { })]
     public class Object_isPlaceable_Patch
     {
         public static void Postfix(StardewValley.Object __instance, ref bool __result)
@@ -52,8 +52,8 @@ namespace HardyGrass
         }
     }
 
-    [HarmonyPatch(typeof(StardewValley.Object))]
-    [HarmonyPatch("isPassable", new Type[] { })]
+    //[HarmonyPatch(typeof(StardewValley.Object))]
+    //[HarmonyPatch("isPassable", new Type[] { })]
     public class Object_isPassable_Patch
     {
         public static void Postfix(StardewValley.Object __instance, ref bool __result)


### PR DESCRIPTION
On 64bit Harmony Patches can't be applied via annotations + PatchAll(). I changed how the patches are done so that it works on 64bit versions of Stardew Valley. I also edited the Harmony references so it works with SMAPI 3.12+ (without SMAPI rewriting it)